### PR TITLE
Add UI flow to register new users

### DIFF
--- a/app_restaurante.py
+++ b/app_restaurante.py
@@ -1,69 +1,123 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-Created on Mon Nov  4 05:07:35 2024
-
-@author: mauricio
+Aplicación principal de Streamlit para la gestión de recetas.
 """
-
-import streamlit as st
-import componentes_ingredientes
-import componentes_recetas
-import componentes_buscar_recetas
-import graficos
 
 import time
 
+import streamlit as st
+
+import auth
+import componentes_buscar_recetas
+import componentes_ingredientes
+import componentes_recetas
+import graficos
+
 st.set_page_config(layout='wide', page_icon=":male_cook:")
 
-def crear_session_state(usuario, Contraseña):
-    if 'user_session' not in st.session_state:
-        st.session_state['user_session'] = usuario
-    if 'pass_session' not in st.session_state:
-        st.session_state['pass_session'] = Contraseña
+AUTH_SESSION_KEY = 'auth_user'
 
-def verificar_login(usuario, contraseña):
-    if usuario == 'chef_loquillo' and contraseña == 'tiramisu980':
-        return True
-    else:
-        st.error('Datos Mal Ingresados')
-        del st.session_state['user_session']
-        del st.session_state['pass_session']
-        time.sleep(2)
-        return False
-def login():
-    if 'user_session' in st.session_state and 'pass_session' in st.session_state:
-        if verificar_login(st.session_state['user_session'],st.session_state['pass_session']):
-            visualizar_elementos()
-        else:
+
+def _mostrar_logout(usuario: str) -> None:
+    """Renderiza los controles de cierre de sesión en la barra lateral."""
+    with st.sidebar:
+        st.write(f"👤 Sesión iniciada como: **{usuario}**")
+        if st.button('Cerrar sesión'):
+            st.session_state.pop(AUTH_SESSION_KEY, None)
             st.rerun()
-    else:
-        _col_relleno1, _col_container, _col_relleno2 = st.columns(3)
-        with _col_container:
-            with st.container(border=True):
-                st.image('chef.jpg')
-                usuario = st.text_input('Ingresar Nombre de Usuario: ')
-                contraseña = st.text_input('Ingresar Contraseña: ', type='password')
-                if st.button('Iniciar Sesion'):
-                    crear_session_state(usuario, contraseña)
+
+
+def login() -> None:
+    """Controla el flujo de autenticación del usuario."""
+    auth.initialize_user_table()
+
+    if AUTH_SESSION_KEY in st.session_state:
+        usuario = st.session_state[AUTH_SESSION_KEY]
+        _mostrar_logout(usuario)
+        visualizar_elementos(usuario)
+        return
+
+    if 'show_register' not in st.session_state:
+        st.session_state['show_register'] = False
+
+    _col_relleno1, _col_container, _col_relleno2 = st.columns(3)
+    with _col_container:
+        with st.container(border=True):
+            st.image('chef.jpg')
+
+            if not st.session_state['show_register']:
+                with st.form('login_form'):
+                    usuario = st.text_input('Ingresar Nombre de Usuario: ')
+                    contraseña = st.text_input('Ingresar Contraseña: ', type='password')
+                    iniciar = st.form_submit_button('Iniciar Sesión')
+
+                if iniciar:
+                    if auth.verify_user(usuario, contraseña):
+                        st.session_state[AUTH_SESSION_KEY] = usuario
+                        st.success('Autenticación exitosa. Redirigiendo...')
+                        time.sleep(1)
+                        st.rerun()
+                    else:
+                        st.error('Credenciales inválidas. Por favor, inténtalo de nuevo.')
+
+                if st.button('Registrar nuevo usuario'):
+                    st.session_state['show_register'] = True
                     st.rerun()
-                    
-def visualizar_elementos():
+            else:
+                st.subheader('Registrar nuevo usuario')
+                with st.form('register_form'):
+                    nuevo_usuario = st.text_input('Nuevo nombre de usuario: ')
+                    nueva_contraseña = st.text_input('Nueva contraseña: ', type='password')
+                    confirmar_contraseña = st.text_input('Confirmar contraseña: ', type='password')
+                    registrar = st.form_submit_button('Crear usuario')
+
+                if registrar:
+                    if not nuevo_usuario or not nueva_contraseña:
+                        st.error('Debes completar todos los campos para registrar un usuario.')
+                    elif nueva_contraseña != confirmar_contraseña:
+                        st.error('Las contraseñas no coinciden. Intenta nuevamente.')
+                    else:
+                        try:
+                            auth.create_user(nuevo_usuario, nueva_contraseña)
+                        except ValueError as exc:
+                            st.error(str(exc))
+                        except Exception:
+                            st.error('Ocurrió un error inesperado al crear el usuario.')
+                        else:
+                            st.success('Usuario creado correctamente. Ahora puedes iniciar sesión.')
+                            st.session_state['show_register'] = False
+                            st.rerun()
+
+                if st.button('Cancelar registro'):
+                    st.session_state['show_register'] = False
+                    st.rerun()
+
+
+def visualizar_elementos(usuario: str) -> None:
+    """Renderiza el contenido principal de la aplicación cuando el usuario está autenticado."""
 
     st.write('## Bienvenido a la Aplicacion de Recetas')
-    
-    tab_nuevos_ingredientes, tab_nueva_receta, tab_buscar_receta, tab_graficos = st.tabs(['Agregar Ingredientes', 'Nueva Receta', 'Buscar Receta', 'Ver Reporte'])
-    
+    st.info(f'Usuario autenticado: **{usuario}**')
+
+    tab_nuevos_ingredientes, tab_nueva_receta, tab_buscar_receta, tab_graficos = st.tabs([
+        'Agregar Ingredientes',
+        'Nueva Receta',
+        'Buscar Receta',
+        'Ver Reporte',
+    ])
+
     with tab_nuevos_ingredientes:
         componentes_ingredientes.main_ingredientes()
-    
+
     with tab_nueva_receta:
         componentes_recetas.main_recetas()
-    
+
     with tab_buscar_receta:
         componentes_buscar_recetas.main_buscar_recetas()
-    
+
     with tab_graficos:
-       graficos.main_graficos()
+        graficos.main_graficos()
+
 
 login()

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,145 @@
+"""Utilities for secure user authentication."""
+from __future__ import annotations
+
+import argparse
+import base64
+import os
+import sqlite3
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+import hashlib
+import hmac
+from typing import Iterable, Tuple
+
+_DB_PATH = Path(__file__).resolve().parent / "recetas.db"
+_PBKDF2_ITERATIONS = 200_000
+_SALT_BYTES = 16
+
+
+def _get_connection() -> sqlite3.Connection:
+    """Return a SQLite connection to the project database."""
+    return sqlite3.connect(_DB_PATH)
+
+
+@contextmanager
+def db_cursor() -> Iterable[sqlite3.Cursor]:
+    """Context manager that yields a database cursor and commits on success."""
+    connection = _get_connection()
+    cursor = connection.cursor()
+    try:
+        yield cursor
+        connection.commit()
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def initialize_user_table() -> None:
+    """Create the user table if it does not exist."""
+    with db_cursor() as cursor:
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS usuario (
+                id_usuario INTEGER PRIMARY KEY AUTOINCREMENT,
+                nombre_usuario TEXT UNIQUE NOT NULL,
+                hash_contrasena TEXT NOT NULL,
+                sal_contrasena TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+
+
+def _hash_password(password: str, salt: bytes | None = None) -> Tuple[str, str]:
+    """Generate a PBKDF2 hash for the provided password."""
+    if not isinstance(password, str) or not password:
+        raise ValueError("La contraseña debe ser una cadena no vacía.")
+
+    salt_bytes = salt if salt is not None else os.urandom(_SALT_BYTES)
+    derived_key = hashlib.pbkdf2_hmac(
+        "sha256",
+        password.encode("utf-8"),
+        salt_bytes,
+        _PBKDF2_ITERATIONS,
+    )
+    return base64.b64encode(salt_bytes).decode("utf-8"), base64.b64encode(derived_key).decode("utf-8")
+
+
+def create_user(username: str, password: str, *, overwrite: bool = False) -> None:
+    """Create a new user with a securely hashed password."""
+    if not isinstance(username, str) or not username:
+        raise ValueError("El nombre de usuario debe ser una cadena no vacía.")
+
+    initialize_user_table()
+    salt_b64, hash_b64 = _hash_password(password)
+
+    with db_cursor() as cursor:
+        cursor.execute(
+            "SELECT id_usuario FROM usuario WHERE nombre_usuario = ?",
+            (username,),
+        )
+        existing = cursor.fetchone()
+        if existing and not overwrite:
+            raise ValueError("El usuario ya existe. Use --overwrite para reemplazarlo.")
+        if existing and overwrite:
+            cursor.execute(
+                "UPDATE usuario SET hash_contrasena = ?, sal_contrasena = ? WHERE nombre_usuario = ?",
+                (hash_b64, salt_b64, username),
+            )
+        else:
+            cursor.execute(
+                "INSERT INTO usuario (nombre_usuario, hash_contrasena, sal_contrasena) VALUES (?, ?, ?)",
+                (username, hash_b64, salt_b64),
+            )
+
+
+def verify_user(username: str, password: str) -> bool:
+    """Return True if the provided credentials match a stored user."""
+    initialize_user_table()
+    with db_cursor() as cursor:
+        cursor.execute(
+            "SELECT hash_contrasena, sal_contrasena FROM usuario WHERE nombre_usuario = ?",
+            (username,),
+        )
+        row = cursor.fetchone()
+    if row is None:
+        return False
+
+    stored_hash_b64, salt_b64 = row
+    salt = base64.b64decode(salt_b64.encode("utf-8"))
+    _, computed_hash_b64 = _hash_password(password, salt=salt)
+    return hmac.compare_digest(stored_hash_b64, computed_hash_b64)
+
+
+def _parse_args(argv: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Gestión de usuarios para la aplicación de recetas.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    create_parser = subparsers.add_parser("crear-usuario", help="Crear o actualizar un usuario")
+    create_parser.add_argument("usuario", help="Nombre de usuario a crear")
+    create_parser.add_argument("contraseña", help="Contraseña para el usuario")
+    create_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Sobrescribe la contraseña si el usuario ya existe.",
+    )
+
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    if args.command == "crear-usuario":
+        try:
+            create_user(args.usuario, args.contraseña, overwrite=args.overwrite)
+            print(f"Usuario '{args.usuario}' creado/actualizado correctamente.")
+            return 0
+        except ValueError as exc:  # pragma: no cover - user input validation
+            print(exc, file=sys.stderr)
+            return 1
+    raise ValueError("Comando desconocido")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/login_seguro.md
+++ b/docs/login_seguro.md
@@ -1,0 +1,60 @@
+# Autenticación segura en la aplicación de recetas
+
+Este documento describe la implementación del nuevo sistema de autenticación segura para la aplicación Streamlit y los pasos necesarios para gestionarlo correctamente.
+
+## 1. Resumen de la solución
+
+- Las credenciales ya no están codificadas en el código fuente.
+- Las contraseñas se almacenan utilizando PBKDF2-HMAC con SHA-256, 200 000 iteraciones y una sal aleatoria por usuario.
+- Las comprobaciones de acceso se realizan contra la tabla `usuario` en la base de datos `recetas.db`.
+- El módulo `auth.py` ofrece utilidades reutilizables para crear cuentas y validar credenciales.
+
+## 2. Creación y actualización de usuarios
+
+### 2.1 Desde la interfaz web
+
+- En la pantalla de inicio de sesión encontrarás el botón **"Registrar nuevo usuario"**.
+- Al pulsarlo se despliega un formulario independiente en el que debes indicar el nombre de usuario, la contraseña y su confirmación.
+- La contraseña se valida de forma local; si las entradas coinciden y no hay errores, se invoca a `auth.create_user` para almacenar el hash y la sal.
+- Tras un registro exitoso, la interfaz vuelve automáticamente al formulario de inicio de sesión para que puedas autenticarte con las nuevas credenciales.
+
+### 2.2 Desde la línea de comandos
+
+1. Asegúrate de tener un entorno virtual activo (opcional pero recomendado).
+2. Ejecuta el siguiente comando para crear un usuario inicial:
+
+   ```bash
+   cd proyecto_restaurant
+   python -m auth crear-usuario <USUARIO> <CONTRASEÑA>
+   ```
+
+   Reemplaza `<USUARIO>` y `<CONTRASEÑA>` por los valores deseados. El comando generará automáticamente una sal aleatoria y guardará el hash en la base de datos.
+
+3. Si necesitas cambiar la contraseña de un usuario existente, reutiliza el mismo comando añadiendo la bandera `--overwrite`:
+
+   ```bash
+   python -m auth crear-usuario <USUARIO> <NUEVA_CONTRASEÑA> --overwrite
+   ```
+
+   El sistema validará que el nombre de usuario no esté vacío y confirmará por consola el resultado de la operación.
+
+## 3. Flujo de autenticación en la interfaz
+
+- Al abrir la aplicación, se muestra un formulario de inicio de sesión protegido (`app_restaurante.py`).
+- En cualquier momento se puede alternar al formulario de registro para crear una cuenta nueva sin abandonar la pantalla.
+- Tras enviar las credenciales, se verifica el hash almacenado mediante `auth.verify_user`.
+- Si la verificación es exitosa, se almacena únicamente el nombre de usuario en la sesión (`st.session_state['auth_user']`).
+- Desde la barra lateral es posible cerrar la sesión de forma segura.
+
+## 4. Inicialización de la base de datos
+
+El script `script_crear_db.py` sigue siendo responsable de crear las tablas principales de recetas y ahora también garantiza que la tabla `usuario` exista mediante `auth.initialize_user_table()`. Puedes ejecutar el script tantas veces como sea necesario; las tablas se crean sólo si no existen.
+
+## 5. Buenas prácticas adicionales
+
+- Usa contraseñas robustas y evita compartirlas por canales inseguros.
+- Renueva periódicamente las contraseñas utilizando el comando con `--overwrite`.
+- Considera almacenar las credenciales sensibles (como contraseñas temporales) en gestores de contraseñas.
+- Si despliegas la aplicación públicamente, utiliza HTTPS para proteger las credenciales en tránsito.
+
+Con estos pasos, la aplicación dispone de un inicio de sesión consistente con buenas prácticas de seguridad y fácilmente extensible para futuras mejoras.

--- a/script_crear_db.py
+++ b/script_crear_db.py
@@ -8,6 +8,8 @@ Created on Wed Nov 13 04:11:40 2024
 
 import sqlite3
 
+import auth
+
 # Conectar y crear el archivo de base de datos
 conn = sqlite3.connect('recetas.db')
 cursor = conn.cursor()
@@ -55,6 +57,9 @@ cursor.execute('''
         FOREIGN KEY (id_subelaboracion) REFERENCES receta(id_receta)
     )
 ''')
+
+# Crear la tabla de usuarios segura
+auth.initialize_user_table()
 
 # Guardar los cambios
 conn.commit()


### PR DESCRIPTION
## Summary
- add a toggleable registration form to the Streamlit login screen so new users can create accounts
- reuse the secure hashing utilities to validate and store credentials from the UI
- document the new in-app registration process alongside the existing CLI instructions

## Testing
- `python -m compileall .` *(fails: existing SyntaxError in componentes_ingredientes.py, unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d70d4a7d5c832eb7d9676994abbeb3